### PR TITLE
Fixing incorrect npm perms install with nvm

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -13,7 +13,6 @@
         - php5-curl
         - git
         - ruby
-        - npm
         #- redis
 
     - name: Enable php5-extensions
@@ -25,17 +24,21 @@
     - name: Composer | Install PHP Composer
       action: shell curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
 
+    - name: Install NVM
+      action: shell curl https://raw.githubusercontent.com/creationix/nvm/v0.17.0/install.sh | bash
+
+    - name: Install Node and NPM
+      action: shell nvm install 0.10
+
+    - name: Activate Node and NPM
+      action: nvm use 0.10
+
     - name: Install NPM build tools
       npm: name={{ item }} global=yes
-      sudo: yes
       with_items:
         - bower
         - gulp-imagemin
         - gulp
-
-    - name: symlink Node
-      sudo: yes
-      file: path=/usr/bin/node src=/usr/bin/nodejs state=link
 
     - name: Install bundler
       gem: name=bundler

--- a/wercker-box.yml
+++ b/wercker-box.yml
@@ -1,5 +1,5 @@
 name: scholarship
-version: 0.0.6
+version: 0.0.7
 inherits: typester/ubuntu14.04-ansible@1.6.6
 type: service
 platform: ubuntu@12.04
@@ -11,6 +11,6 @@ keywords:
   - bower
   - gulp
 packages:
-  - scholarship@0.0.6
+  - scholarship@0.0.7
 script: |
     sudo ansible-playbook -v site.yml -i inventory.ini -c local


### PR DESCRIPTION
NPM was being installed as an apt package with sudo which completely messes up the permissions on a dev box.  Doing the installation correctly as referenced here to avoid having to run everything with sudo:

http://stackoverflow.com/questions/16151018/npm-throws-error-without-sudo/24404451#24404451
